### PR TITLE
fix(error): Lock GetLastError to OS Thread

### DIFF
--- a/wasmer/error.go
+++ b/wasmer/error.go
@@ -5,8 +5,8 @@ import (
 	"unsafe"
 )
 
-// GetLastError returns the last error message if any, otherwise returns an error.
-func GetLastError() (string, error) {
+// getLastError returns the last error message if any, otherwise returns an error.
+func getLastError() (string, error) {
 	var errorLength = cWasmerLastErrorLength()
 
 	if errorLength == 0 {

--- a/wasmer/memory.go
+++ b/wasmer/memory.go
@@ -3,6 +3,7 @@ package wasmer
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"unsafe"
 )
 
@@ -69,10 +70,12 @@ func (memory *Memory) Grow(numberOfPages uint32) error {
 		return nil
 	}
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	var growResult = cWasmerMemoryGrow(memory.memory, cUint32T(numberOfPages))
 
 	if growResult != cWasmerOk {
-		var lastError, err = GetLastError()
+		var lastError, err = getLastError()
 		var errorMessage = "Failed to grow the memory:\n    %s"
 
 		if err != nil {


### PR DESCRIPTION
GetLastError requires being locked to the OS Thread where the error was
generated. This is subtle and easy to get wrong. This commit hides
GetLastError and integrates its use with the proper use of
runtime.LockOSThread.

fix #96 

This is an initial pass. I'm not super happy with how I am returning the error details in the Exports function call closure, but I was trying to modify as little as possible. If a user wants to see the error details they will need to type assert the error into an ExportedFunctionError and then they can grab just the Err field. Or they can parse the Error string which includes the detailed error string after the "Failed to call %s exported function." with a colon and space in between.