### PR TITLE
Panic on wasi import object

### DIFF
--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -1,10 +1,11 @@
 package wasmertest
 
 import (
-	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 	"testing"
 	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 )
 
 func TestInstanceImport(t *testing.T) {
@@ -59,6 +60,7 @@ func TestImportInstanceContextData(t *testing.T) {
 
 func TestWasiImportObject(t *testing.T) {
 	testWasiImportObject(t)
+	testWasiImportObjectWithEnv(t)
 }
 
 func TestImportMemory(t *testing.T) {


### PR DESCRIPTION
Failing test for https://github.com/wasmerio/go-ext-wasm/issues/127:

```
Running tool: /usr/local/go/bin/go test -timeout 60s github.com/wasmerio/go-ext-wasm/wasmer/test -run ^(TestWasiImportObject)$

hello world
!--- FAIL: TestWasiImportObject (0.00s)
panic: runtime error: cgo argument has Go pointer to Go pointer [recovered]
	panic: runtime error: cgo argument has Go pointer to Go pointer

goroutine 6 [running]:
testing.tRunner.func1.1(0x6f8c80, 0xc00006ef10)
	/usr/local/go/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc0000b8480)
	/usr/local/go/src/testing/testing.go:944 +0x3f9
panic(0x6f8c80, 0xc00006ef10)
	/usr/local/go/src/runtime/panic.go:967 +0x166
github.com/wasmerio/go-ext-wasm/wasmer.cNewWasmerWasiImportObject.func1(0xc00000e3e0, 0x0, 0xc00000e400, 0x1, 0xc00000e420, 0x0, 0xc00000e440, 0x0, 0xc00000e440)
	/home/karolis/go/src/github.com/wasmerio/go-ext-wasm/wasmer/bridge.go:233 +0x65
github.com/wasmerio/go-ext-wasm/wasmer.cNewWasmerWasiImportObject(0xc00000e3e0, 0x0, 0xc00000e400, 0x1, 0xc00000e420, 0x0, 0xc00000e440, 0x0, 0x0)
	/home/karolis/go/src/github.com/wasmerio/go-ext-wasm/wasmer/bridge.go:233 +0x7e
github.com/wasmerio/go-ext-wasm/wasmer.NewWasiImportObjectForVersion(0x3, 0x0, 0x0, 0x0, 0xc00006eef0, 0x1, 0x1, 0x0, 0x0, 0x0, ...)
	/home/karolis/go/src/github.com/wasmerio/go-ext-wasm/wasmer/wasi.go:101 +0x40d
github.com/wasmerio/go-ext-wasm/wasmer/test.testWasiImportObjectWithEnv(0xc0000b8480)
	/home/karolis/go/src/github.com/wasmerio/go-ext-wasm/wasmer/test/imports.go:314 +0x275
github.com/wasmerio/go-ext-wasm/wasmer/test.TestWasiImportObject(0xc0000b8480)
	/home/karolis/go/src/github.com/wasmerio/go-ext-wasm/wasmer/test/import_test.go:63 +0x39
testing.tRunner(0xc0000b8480, 0x76a878)
	/usr/local/go/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1043 +0x357
FAIL	github.com/wasmerio/go-ext-wasm/wasmer/test	0.008s
FAIL
Error: Tests failed.
```




I have never used cgo before, if there are any pointers I could follow then I could try to debug this further.

Actually it seems that it's complaining about these lines (that func that takes the args): https://github.com/wasmerio/go-ext-wasm/blob/master/wasmer/bridge.go#L225-L235 
