### PR TITLE
Renamed go-ext-wasm to wasmer-go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           just test
 # Skipped for now because of Github banning the API request from actions.
-# You can find more info in this PR: https://github.com/wasmerio/go-ext-wasm/pull/118#issuecomment-588487544
+# You can find more info in this PR: https://github.com/wasmerio/wasmer-go/pull/118#issuecomment-588487544
 #       - name: Test bazel build
 #         shell: bash
 #         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 * Replace godoc.org by pkg.go.dev
-  ([#122](https://github.com/wasmerio/go-ext-wasm/pull/122) by
+  ([#122](https://github.com/wasmerio/wasmer-go/pull/122) by
   [@Hywan])
 * Do everything to publish the package on pkg.go.dev.
 
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 
 * Memory can be imported, thus making the distinction between owned
   and borrowed memory
-  ([#119](https://github.com/wasmerio/go-ext-wasm/pull/119) by
+  ([#119](https://github.com/wasmerio/wasmer-go/pull/119) by
   [@koponen-styra]).
 
   The main new methods are `Imports.AppendMemory`, and `NewMemory` to
@@ -55,12 +55,12 @@ All notable changes to this project will be documented in this file.
   ```
   
 * Add Bazel files to build the project with Bazel
-  ([#108](https://github.com/wasmerio/go-ext-wasm/pull/108) by
+  ([#108](https://github.com/wasmerio/wasmer-go/pull/108) by
   [@joesonw])
 * Support multiple WASI version with `WasiGetVersion`,
   `NewDefaultWasiImportObjectForVersion`,
   `NewWasiImportObjectForVersion` and `WasiVersion`
-  ([#92](https://github.com/wasmerio/go-ext-wasm/pull/92) by
+  ([#92](https://github.com/wasmerio/wasmer-go/pull/92) by
   [@Hywan]).
 
   Supported version are:
@@ -90,8 +90,8 @@ All notable changes to this project will be documented in this file.
 
 * `InstanceContext` supports user data with any reference types or
   types that include any reference types or other Go pointers
-  ([#85](https://github.com/wasmerio/go-ext-wasm/pull/85) and
-  [#94](https://github.com/wasmerio/go-ext-wasm/pull/94) by
+  ([#85](https://github.com/wasmerio/wasmer-go/pull/85) and
+  [#94](https://github.com/wasmerio/wasmer-go/pull/94) by
   [@AdamSLevy])
   
   ```go
@@ -112,7 +112,7 @@ All notable changes to this project will be documented in this file.
   ```
 
 * WASI is now supported
-  ([#72](https://github.com/wasmerio/go-ext-wasm/pull/72) by
+  ([#72](https://github.com/wasmerio/wasmer-go/pull/72) by
   [@MarkMcCaskey])
   
   ```go
@@ -138,43 +138,43 @@ All notable changes to this project will be documented in this file.
   
 * `Instance` supports optional memory, i.e. a WebAssembly module that
   does not have an exported memory, and provides a new `HasMemory`
-  method ([#63](https://github.com/wasmerio/go-ext-wasm/pull/63) by
+  method ([#63](https://github.com/wasmerio/wasmer-go/pull/63) by
   [@Hywan])
 
 ### Changed
 
 * Remove unnecessary heap allocations and calls to C
-  ([#118](https://github.com/wasmerio/go-ext-wasm/pull/118) by
+  ([#118](https://github.com/wasmerio/wasmer-go/pull/118) by
   [@koponen-styra])
 * Update the `cli` package version to v2
-  ([#110](https://github.com/wasmerio/go-ext-wasm/pull/110) by
+  ([#110](https://github.com/wasmerio/wasmer-go/pull/110) by
   [@d0iasm])
 * Migrate from CircleCI to Github Actions
-  ([#99](https://github.com/wasmerio/go-ext-wasm/pull/99) and
-  [#103](https://github.com/wasmerio/go-ext-wasm/pull/103) by
+  ([#99](https://github.com/wasmerio/wasmer-go/pull/99) and
+  [#103](https://github.com/wasmerio/wasmer-go/pull/103) by
   [@Hywan])
 * Explain how this package works
-  ([#97](https://github.com/wasmerio/go-ext-wasm/pull/97) by [@Hywan])
+  ([#97](https://github.com/wasmerio/wasmer-go/pull/97) by [@Hywan])
 * Make tests more portable by changing `int64_t` to `long long` in cgo
-  ([#67](https://github.com/wasmerio/go-ext-wasm/pull/67) by
+  ([#67](https://github.com/wasmerio/wasmer-go/pull/67) by
   [@ethanfrey])
 * Update build instructions
-  ([#66](https://github.com/wasmerio/go-ext-wasm/pull/66) by
+  ([#66](https://github.com/wasmerio/wasmer-go/pull/66) by
   [@ethanfrey])
 * Update Wasmer to 0.6.0 to 0.14.0
-  ([#57](https://github.com/wasmerio/go-ext-wasm/pull/57),
-  [#64](https://github.com/wasmerio/go-ext-wasm/pull/64),
-  [#73](https://github.com/wasmerio/go-ext-wasm/pull/73),
-  [#80](https://github.com/wasmerio/go-ext-wasm/pull/80),
-  [#89](https://github.com/wasmerio/go-ext-wasm/pull/89),
-  [#107](https://github.com/wasmerio/go-ext-wasm/pull/107),
-  [#111](https://github.com/wasmerio/go-ext-wasm/pull/111) and
-  [#120](https://github.com/wasmerio/go-ext-wasm/pull/120) by [@Hywan])
+  ([#57](https://github.com/wasmerio/wasmer-go/pull/57),
+  [#64](https://github.com/wasmerio/wasmer-go/pull/64),
+  [#73](https://github.com/wasmerio/wasmer-go/pull/73),
+  [#80](https://github.com/wasmerio/wasmer-go/pull/80),
+  [#89](https://github.com/wasmerio/wasmer-go/pull/89),
+  [#107](https://github.com/wasmerio/wasmer-go/pull/107),
+  [#111](https://github.com/wasmerio/wasmer-go/pull/111) and
+  [#120](https://github.com/wasmerio/wasmer-go/pull/120) by [@Hywan])
   
 ### Fixed
 
 * Fix build for go1.14beta1 on macOS
-  ([#114](https://github.com/wasmerio/go-ext-wasm/pull/114) by
+  ([#114](https://github.com/wasmerio/wasmer-go/pull/114) by
   [@chai2010])
 
 ## [0.2.0] - 2019-07-16
@@ -182,11 +182,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * Add the `Memory.Grow` method
-  ([#55](https://github.com/wasmerio/go-ext-wasm/pull/55) by [@Hywan])
+  ([#55](https://github.com/wasmerio/wasmer-go/pull/55) by [@Hywan])
 * Improve error messages when instantiating
-  ([#42](https://github.com/wasmerio/go-ext-wasm/pull/42) by [@Hywan])
+  ([#42](https://github.com/wasmerio/wasmer-go/pull/42) by [@Hywan])
 * Support import descriptors
-  ([#38](https://github.com/wasmerio/go-ext-wasm/pull/38) by [@Hywan])
+  ([#38](https://github.com/wasmerio/wasmer-go/pull/38) by [@Hywan])
 
   ```go
   var module, _ = wasm.Compile(bytes)
@@ -196,7 +196,7 @@ All notable changes to this project will be documented in this file.
   ```
 
 * Support export descriptors
-  ([#37](https://github.com/wasmerio/go-ext-wasm/pull/37) by [@Hywan])
+  ([#37](https://github.com/wasmerio/wasmer-go/pull/37) by [@Hywan])
 
   ```go
   var module, _ = wasm.Compile(bytes)
@@ -205,7 +205,7 @@ All notable changes to this project will be documented in this file.
   ```
 
 * Support module serialization and deserialization
-  ([#34](https://github.com/wasmerio/go-ext-wasm/pull/34) by [@Hywan])
+  ([#34](https://github.com/wasmerio/wasmer-go/pull/34) by [@Hywan])
 
   ```go
   // Compiles the bytes into a WebAssembly module.
@@ -243,9 +243,9 @@ All notable changes to this project will be documented in this file.
   ```
 
 * Add `Compile`, `Module.Instantiate*` and `Module.Close`
-  ([#33](https://github.com/wasmerio/go-ext-wasm/pull/33) by [@Hywan])
+  ([#33](https://github.com/wasmerio/wasmer-go/pull/33) by [@Hywan])
 * Support instance context data
-  ([#30](https://github.com/wasmerio/go-ext-wasm/pull/30) by [@Hywan])
+  ([#30](https://github.com/wasmerio/wasmer-go/pull/30) by [@Hywan])
 
   ```go
   //export logMessageWithContextData
@@ -284,7 +284,7 @@ All notable changes to this project will be documented in this file.
   ```
 
 * Add `Imports.Namespace` to set the current import namespace
-  ([#29](https://github.com/wasmerio/go-ext-wasm/pull/29) by [@Hywan])
+  ([#29](https://github.com/wasmerio/wasmer-go/pull/29) by [@Hywan])
 
   ```go
   // By default, the namespace is `"env"`. Change it to `"ns"`.
@@ -292,36 +292,36 @@ All notable changes to this project will be documented in this file.
   ```
 
 * Support instance context API
-  ([#26](https://github.com/wasmerio/go-ext-wasm/pull/26) by [@Hywan])
+  ([#26](https://github.com/wasmerio/wasmer-go/pull/26) by [@Hywan])
 
 ### Changed
 
 * Update Wasmer to 0.5.5
-  ([#56](https://github.com/wasmerio/go-ext-wasm/pull/56) by [@Hywan])
+  ([#56](https://github.com/wasmerio/wasmer-go/pull/56) by [@Hywan])
 * Test that all Wasm types can be used in imported functions
-  ([#51](https://github.com/wasmerio/go-ext-wasm/pull/51) by [@Hywan])
+  ([#51](https://github.com/wasmerio/wasmer-go/pull/51) by [@Hywan])
 * Improve the Benchmarks Section
-  ([#36](https://github.com/wasmerio/go-ext-wasm/pull/36) by [@Hywan])
+  ([#36](https://github.com/wasmerio/wasmer-go/pull/36) by [@Hywan])
 * Move examples in the root directory for godoc.org
-  ([#32](https://github.com/wasmerio/go-ext-wasm/pull/32) by [@Hywan])
+  ([#32](https://github.com/wasmerio/wasmer-go/pull/32) by [@Hywan])
 * Fix example namespaces for godoc.org
-  ([#31](https://github.com/wasmerio/go-ext-wasm/pull/31) by [@Hywan])
+  ([#31](https://github.com/wasmerio/wasmer-go/pull/31) by [@Hywan])
 * Increase the `cgocheck` level
-  ([#30](https://github.com/wasmerio/go-ext-wasm/pull/30) by [@Hywan])
+  ([#30](https://github.com/wasmerio/wasmer-go/pull/30) by [@Hywan])
 * Reorganize `bridge.go`
-  ([#54](https://github.com/wasmerio/go-ext-wasm/pull/54) by [@Hywan])
+  ([#54](https://github.com/wasmerio/wasmer-go/pull/54) by [@Hywan])
 * Build and test on macOS
-  ([#15](https://github.com/wasmerio/go-ext-wasm/pull/15) by [@Hywan])
+  ([#15](https://github.com/wasmerio/wasmer-go/pull/15) by [@Hywan])
 
 ## 0.1.0 - 2019-05-29
 
 First release.
 
 
-[Unreleased]: https://github.com/wasmerio/go-ext-wasm/compare/v0.3.1...HEAD
-[0.3.1]: https://github.com/wasmerio/go-ext-wasm/compare/0.3.0...v0.3.1
-[0.3.0]: https://github.com/wasmerio/go-ext-wasm/compare/0.2.0...0.3.0
-[0.2.0]: https://github.com/wasmerio/go-ext-wasm/compare/0.1.0...0.2.0
+[Unreleased]: https://github.com/wasmerio/wasmer-go/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/wasmerio/wasmer-go/compare/0.3.0...v0.3.1
+[0.3.0]: https://github.com/wasmerio/wasmer-go/compare/0.2.0...0.3.0
+[0.2.0]: https://github.com/wasmerio/wasmer-go/compare/0.1.0...0.2.0
 [@Hywan]: https://github.com/Hywan
 [@ethanfrey]: https://github.com/ethanfrey
 [@MarkMcCaskey]: https://github.com/MarkMcCaskey

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,13 +332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "go-ext-wasm"
-version = "0.2.0"
-dependencies = [
- "wasmer-runtime-c-api 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +851,13 @@ dependencies = [
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.45.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasmer-go"
+version = "0.2.0"
+dependencies = [
+ "wasmer-runtime-c-api 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 publish = false
-name = "go-ext-wasm"
+name = "wasmer-go"
 version = "0.2.0"
 authors = ["Ivan Enderlin <ivan.enderlin@hoa-project.net>"]
 edition = "2018"
 description = "Go library to run WebAssembly binaries"
 readme = "README.md"
-repository = "https://github.com/wasmerio/go-ext-wasm"
+repository = "https://github.com/wasmerio/wasmer-go"
 keywords = ["golang", "extension", "webassembly"]
 categories = ["wasm"]
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ If you are a bazel user, add following to your WORKSPACE file
 
 ```
 git_repository(
-    name = "com_github_wasmerio_go_ext_wasm",
+    name = "com_github_wasmerio_wasmer_go",
     remote = "https://github.com/wasmerio/wasmer-go",
     commit = "",
 )

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-<p align="center">
-  <a href="https://wasmer.io" target="_blank" rel="noopener">
-    <img width="300" src="https://raw.githubusercontent.com/wasmerio/wasmer/master/assets/logo.png" alt="Wasmer logo">
-  </a>
-</p>
+# <img height="48" src="https://wasmer.io/static/icons/favicon-96x96.png" alt="Wasmer logo" valign="middle"> Wasmer Go [![Packagist version](https://img.shields.io/badge/go.dev-package-f06)](https://pkg.go.dev/github.com/wasmerio/wasmer-go/wasmer) [![Wasmer Go Documentation](https://img.shields.io/badge/documentation-API-ff0066.svg)](https://pkg.go.dev/github.com/wasmerio/wasmer-go/wasmer?tab=doc) [![Wasmer Slack Channel](https://img.shields.io/static/v1?label=chat&message=on%20Slack&color=green)](https://slack.wasmer.io)
 
-<p align="center">
-  <a href="https://spectrum.chat/wasmer">
-    <img src="https://withspectrum.github.io/badge/badge.svg" alt="Join the Wasmer Community" valign="middle"></a>
-  <a href="https://pkg.go.dev/github.com/wasmerio/go-ext-wasm/wasmer">
-    <img src="https://img.shields.io/badge/go.dev-package-f06" alt="Read our API documentation" valign="middle"></a>
-  <a href="https://goreportcard.com/report/github.com/wasmerio/go-ext-wasm">
-    <img src="https://goreportcard.com/badge/github.com/wasmerio/go-ext-wasm" alt="Go Report Card" valign="middle" /></a>
-  <a href="https://github.com/wasmerio/wasmer/blob/master/LICENSE">
-    <img src="https://img.shields.io/github/license/wasmerio/wasmer.svg" alt="License" valign="middle"></a>
-</p>
+A complete and mature WebAssembly runtime for Go based on [Wasmer].
 
-Wasmer is a Go library for executing WebAssembly binaries.
+Features:
+
+  * **Easy to use**: The `wasmer` API mimics the standard WebAssembly API,
+  * **Fast**: `wasmer` executes the WebAssembly modules as fast as
+    possible, close to **native speed**,
+  * **Safe**: All calls to WebAssembly will be fast, but more
+    importantly, completely safe and sandboxed.
+
+[Wasmer]: https://github.com/wasmerio/wasmer
 
 # Install
 
@@ -25,42 +20,13 @@ To install the library, follow the classical:
 # Enable cgo
 $ export CGO_ENABLED=1; export CC=gcc;
 
-$ go get github.com/wasmerio/go-ext-wasm/wasmer
+$ go get github.com/wasmerio/wasmer-go/wasmer
 ```
 
-It will work on many macOS and Linux distributions. It will not work
-on Windows yet, we are working on it.
+> Note: Wasmer doesn't work on Windows yet.
 
-If the pre-compiled shared libraries are not compatible with your system, try installing manually with the following command:
+If the pre-compiled shared libraries are not compatible with your system, you can try [installing it manuallly](#manual-install).
 
-```sh
-$ just build-runtime
-$ just build
-$ go install github.com/wasmerio/go-ext-wasm/wasmer
-```
-
-If you are a bazel user, add following to your WORKSPACE file 
-
-```
-git_repository(
-    name = "com_github_wasmerio_go_ext_wasm",
-    remote = "https://github.com/wasmerio/go-ext-wasm",
-    commit = "",
-)
-```
-
-# Documentation
-
-[The documentation can be read online on pkg.go.dev][documentation]. It
-contains function descriptions, short examples, long examples
-etc. Everything one need to start using Wasmer with Go!
-
-Also, there is this article written for the announcement that
-introduces the project: [Announcing the fastest WebAssembly runtime
-for Go: wasmer][medium].
-
-[documentation]: https://pkg.go.dev/github.com/wasmerio/go-ext-wasm/wasmer?tab=doc
-[medium]: https://medium.com/wasmer/announcing-the-fastest-webassembly-runtime-for-go-wasmer-19832d77c050
 
 # Examples
 
@@ -77,9 +43,9 @@ pub extern fn sum(x: i32, y: i32) -> i32 {
 ```
 
 After compilation to WebAssembly, the
-[`wasmer/test/testdata/examples/simple.wasm`](https://github.com/wasmerio/go-ext-wasm/blob/master/wasmer/test/testdata/examples/simple.wasm)
+[`wasmer/test/testdata/examples/simple.wasm`](https://github.com/wasmerio/wasmer-go/blob/master/wasmer/test/testdata/examples/simple.wasm)
 binary file is generated. ([Download
-it](https://github.com/wasmerio/go-ext-wasm/raw/master/wasmer/test/testdata/examples/simple.wasm)).
+it](https://github.com/wasmerio/wasmer-go/raw/master/wasmer/test/testdata/examples/simple.wasm)).
 
 Then, we can execute it in Go:
 
@@ -88,7 +54,7 @@ package main
 
 import (
 	"fmt"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 )
 
 func main() {
@@ -229,7 +195,20 @@ similar approach.
 
 For a more complete example, see the [Greet Example][greet-example].
 
-[greet-example]: https://godoc.org/github.com/wasmerio/go-ext-wasm/wasmer#example-package--Greet
+[greet-example]: https://godoc.org/github.com/wasmerio/wasmer-go/wasmer#example-package--Greet
+
+# Documentation
+
+[The documentation can be read online on pkg.go.dev][documentation]. It
+contains function descriptions, short examples, long examples
+etc. Everything one need to start using Wasmer with Go!
+
+Also, there is this article written for the announcement that
+introduces the project: [Announcing the fastest WebAssembly runtime
+for Go: wasmer][medium].
+
+[documentation]: https://pkg.go.dev/github.com/wasmerio/wasmer-go/wasmer?tab=doc
+[medium]: https://medium.com/wasmer/announcing-the-fastest-webassembly-runtime-for-go-wasmer-19832d77c050
 
 # Development
 
@@ -251,6 +230,26 @@ $ just build
 (Yes, you need [`just`]).
 
 [`just`]: https://github.com/casey/just/
+
+## Manual Install
+
+You can install Wasmer manually with the following command:
+
+```sh
+$ just build-runtime
+$ just build
+$ go install github.com/wasmerio/wasmer-go/wasmer
+```
+
+If you are a bazel user, add following to your WORKSPACE file 
+
+```
+git_repository(
+    name = "com_github_wasmerio_go_ext_wasm",
+    remote = "https://github.com/wasmerio/wasmer-go",
+    commit = "",
+)
+```
 
 # Testing
 

--- a/benchmarks/life/go.mod
+++ b/benchmarks/life/go.mod
@@ -1,4 +1,4 @@
-module github.com/wasmerio/go-ext-wasm/benchmarks-life
+module github.com/wasmerio/wasmer-go/benchmarks-life
 
 go 1.12
 

--- a/benchmarks/wagon/go.mod
+++ b/benchmarks/wagon/go.mod
@@ -1,4 +1,4 @@
-module github.com/wasmerio/go-ext-wasm/benchmarks-wagon
+module github.com/wasmerio/wasmer-go/benchmarks-wagon
 
 go 1.12
 

--- a/benchmarks/wagon/go.sum
+++ b/benchmarks/wagon/go.sum
@@ -4,8 +4,8 @@ github.com/go-interpreter/wagon v0.4.0/go.mod h1:zHOMvbitcZek8oshsMO5VpyBjWjV9X8
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190522133517-c52507aa3614/go.mod h1:eMc2spdUoaytBSiXb6oJVSyzkYL2TePhYiv09mmP9lA=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190527144709-f55b2a820f3d h1:MHM7qfGonFze9WBpKRz+TicwIWOKr5U0+Jr/wY0hS/E=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190527144709-f55b2a820f3d/go.mod h1:UkqsV9/yC6+lwjqMq7fpBrxhhGKH0VzqT7nAFR4jS9I=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190527154049-20a5840a9e4f h1:xyPd41z0V3O555xDX+iUi69mbM3czwF99ALHI+UBphw=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190527154049-20a5840a9e4f/go.mod h1:UkqsV9/yC6+lwjqMq7fpBrxhhGKH0VzqT7nAFR4jS9I=
+github.com/wasmerio/wasmer-go v0.0.0-20190522133517-c52507aa3614/go.mod h1:eMc2spdUoaytBSiXb6oJVSyzkYL2TePhYiv09mmP9lA=
+github.com/wasmerio/wasmer-go v0.0.0-20190527144709-f55b2a820f3d h1:MHM7qfGonFze9WBpKRz+TicwIWOKr5U0+Jr/wY0hS/E=
+github.com/wasmerio/wasmer-go v0.0.0-20190527144709-f55b2a820f3d/go.mod h1:UkqsV9/yC6+lwjqMq7fpBrxhhGKH0VzqT7nAFR4jS9I=
+github.com/wasmerio/wasmer-go v0.0.0-20190527154049-20a5840a9e4f h1:xyPd41z0V3O555xDX+iUi69mbM3czwF99ALHI+UBphw=
+github.com/wasmerio/wasmer-go v0.0.0-20190527154049-20a5840a9e4f/go.mod h1:UkqsV9/yC6+lwjqMq7fpBrxhhGKH0VzqT7nAFR4jS9I=

--- a/benchmarks/wasmer/benchmarks_test.go
+++ b/benchmarks/wasmer/benchmarks_test.go
@@ -1,7 +1,7 @@
 package wasmer_test
 
 import (
-	"github.com/wasmerio/go-ext-wasm/wasmer"
+	"github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"testing"

--- a/benchmarks/wasmer/go.mod
+++ b/benchmarks/wasmer/go.mod
@@ -1,5 +1,5 @@
-module github.com/wasmerio/go-ext-wasm/benchmarks-wasmer
+module github.com/wasmerio/wasmer-go/benchmarks-wasmer
 
 go 1.12
 
-require github.com/wasmerio/go-ext-wasm v0.0.0-20190529144619-c706f2f0aaf6
+require github.com/wasmerio/wasmer-go v0.0.0-20190529144619-c706f2f0aaf6

--- a/benchmarks/wasmer/go.sum
+++ b/benchmarks/wasmer/go.sum
@@ -2,5 +2,5 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190529144619-c706f2f0aaf6 h1:SDmOFENk2t9BHUprWF0/nGkUCuPti93vIG321bFL04g=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190529144619-c706f2f0aaf6/go.mod h1:UkqsV9/yC6+lwjqMq7fpBrxhhGKH0VzqT7nAFR4jS9I=
+github.com/wasmerio/wasmer-go v0.0.0-20190529144619-c706f2f0aaf6 h1:SDmOFENk2t9BHUprWF0/nGkUCuPti93vIG321bFL04g=
+github.com/wasmerio/wasmer-go v0.0.0-20190529144619-c706f2f0aaf6/go.mod h1:UkqsV9/yC6+lwjqMq7fpBrxhhGKH0VzqT7nAFR4jS9I=

--- a/go-wasmer/BUILD.bazel
+++ b/go-wasmer/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "github.com/wasmerio/go-ext-wasm/go-wasmer",
+    importpath = "github.com/wasmerio/wasmer-go/go-wasmer",
     visibility = ["//visibility:private"],
     deps = [
         "//wasmer:go_default_library",

--- a/go-wasmer/main.go
+++ b/go-wasmer/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/urfave/cli/v2"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"log"
 	"os"
 	"strconv"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wasmerio/go-ext-wasm
+module github.com/wasmerio/wasmer-go
 
 go 1.12
 

--- a/wasmer/BUILD.bazel
+++ b/wasmer/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
      ],
     cgo = True,
     clinkopts = ["-Wl,-rpath,wasmer -Lwasmer/wasmer -lwasmer_runtime_c_api"],
-    importpath = "github.com/wasmerio/go-ext-wasm/wasmer",
+    importpath = "github.com/wasmerio/wasmer-go/wasmer",
     visibility = ["//visibility:public"],
     cdeps = [":wasm"],
 )

--- a/wasmer/_example_import_test.go
+++ b/wasmer/_example_import_test.go
@@ -9,7 +9,7 @@ import "C"
 
 import (
 	"fmt"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"unsafe"

--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -41,7 +41,7 @@ import "unsafe"
 //     |       v              |       |
 //     |  +----+--------------+----+  |
 //     |  |                        |  |
-//     |  |       bridge.go        |  |   go-ext-wasm/wasmer
+//     |  |       bridge.go        |  |   wasmer-go/wasmer
 //     |  |                        |  |
 //     |  +----+--------------+----+  |
 //     |       |              ^       |

--- a/wasmer/example_greet_test.go
+++ b/wasmer/example_greet_test.go
@@ -2,7 +2,7 @@ package wasmer_test
 
 import (
 	"fmt"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"strings"

--- a/wasmer/example_memory_test.go
+++ b/wasmer/example_memory_test.go
@@ -2,7 +2,7 @@ package wasmer_test
 
 import (
 	"fmt"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 )

--- a/wasmer/example_simple_test.go
+++ b/wasmer/example_simple_test.go
@@ -2,7 +2,7 @@ package wasmer_test
 
 import (
 	"fmt"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 )

--- a/wasmer/example_test.go
+++ b/wasmer/example_test.go
@@ -2,7 +2,7 @@ package wasmer_test
 
 import (
 	"fmt"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 )

--- a/wasmer/test/import_test.go
+++ b/wasmer/test/import_test.go
@@ -2,7 +2,7 @@ package wasmertest
 
 import (
 	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"testing"
 	"unsafe"
 )

--- a/wasmer/test/imports.go
+++ b/wasmer/test/imports.go
@@ -16,7 +16,7 @@ import "C"
 import (
 	"encoding/binary"
 	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"testing"

--- a/wasmer/test/instance_test.go
+++ b/wasmer/test/instance_test.go
@@ -2,7 +2,7 @@ package wasmertest
 
 import (
 	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"testing"

--- a/wasmer/test/memory_test.go
+++ b/wasmer/test/memory_test.go
@@ -2,7 +2,7 @@ package wasmertest
 
 import (
 	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"testing"

--- a/wasmer/test/module_test.go
+++ b/wasmer/test/module_test.go
@@ -2,7 +2,7 @@ package wasmertest
 
 import (
 	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"path"
 	"runtime"
 	"testing"

--- a/wasmer/test/value_test.go
+++ b/wasmer/test/value_test.go
@@ -2,7 +2,7 @@ package wasmertest
 
 import (
 	"github.com/stretchr/testify/assert"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
+	wasm "github.com/wasmerio/wasmer-go/wasmer"
 	"testing"
 )
 


### PR DESCRIPTION
* [x] Renamed go-ext-wasm to wasmer-go - https://github.com/wasmerio/wasmer-go/blob/improvements/README.md
* [x] Improved README to match other language structure