### PR TITLE
fix: Imports are verified when module is instantiated

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ examples:
 	#export DYLD_PRINT_LIBRARIES=y
 	cd examples
 	# Run the examples.
-	GODEBUG=cgocheck=2 go test
+	GODEBUG=cgocheck=2 go test -test.v
 
 # Local Variables:
 # mode: makefile

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -11,11 +11,16 @@ type Instance struct {
 
 func NewInstance(module *Module, imports *ImportObject) (*Instance, error) {
 	var traps *C.wasm_trap_t
+	externs, err := imports.intoInner(module)
+
+	if err != nil {
+		return nil, err
+	}
 
 	instance := C.wasm_instance_new(
 		module.store.inner(),
 		module.inner(),
-		imports.intoInner(),
+		externs,
 		&traps,
 	)
 


### PR DESCRIPTION
Before this patch, we had a bug in how imports are handled. Here is an example:

Given the following WAT:

```wat
(module
  (func $host_function (import "" "host_function") (result i32))
  (global $host_global (import "env" "host_global") i32))
```

And the following Go code:

```go

// Create the engine, store and module
//...

importObject := NewImportObject()
importObject.Register(
	"foo",
	map[string]IntoExtern {
		"bar": hostFunction,
	},
)
importObject.Register(
	"bar",
	map[string]IntoExtern {
		"baz": hostGlobal,
	},
)

instance, err := NewInstance(module, importObject)
```

This will pass without any error despite the imports we declared  do not match what the module expects (namespace and name do not match at all).

An other interesting thing is Go randomizes key during iteration so even if the namespace and name matched, we could have some failure.

Conclusion, we have two bugs hidden inside one. But we can go further. Let's assume we have the following Go code:

```go
importObject := wasmer.NewImportObject()
importObject.Register(
	"env",
	map[string]wasmer.IntoExtern{
		"host_global": hostGlobal,
	},
)
importObject.Register(
	"",
	map[string]wasmer.IntoExtern{
		"host_function": hostFunction,
	},
)

instance, err := NewInstance(module, importObject)
```

Namespace and names match but we get failures!

Conclusion (bis):
* Imports' declaration order matters, name and namespaces do not;
* Order is not guaranteed by Go.

This patch is a proposition of a solution to both problems: namespaces and names are used to correctly import externs and see if there are some missing.