### PR TITLE
fix: Correctly initialize LimitMaxUnbound

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,8 @@ jobs:
         target:
           - id: 'linux-amd64'
             os: 'ubuntu-18.04'
-            cc: 'clang-6.0'
           - id: 'darwin-amd64'
             os: 'macos-latest'
-            cc: 'clang'
         go: [1.14]
       fail-fast: true
 
@@ -53,15 +51,11 @@ jobs:
         shell: bash
         run: |
           just test
-        env:
-          CC: ${{ matrix.target.cc }}
 
       - name: Run all the examples
         shell: bash
         run: |
           just examples
-        env:
-          CC: ${{ matrix.target.cc }}
 # Skipped for now because of Github banning the API request from actions.
 # You can find more info in this PR: https://github.com/wasmerio/wasmer-go/pull/118#issuecomment-588487544
 #       - name: Test bazel build

--- a/wasmer/limits.go
+++ b/wasmer/limits.go
@@ -1,10 +1,16 @@
 package wasmer
 
 // #include <wasmer_wasm.h>
+//
+// uint32_t limit_max_unbound() {
+//     return wasm_limits_max_default;
+// }
 import "C"
 import "runtime"
 
-const LimitMaxUnbound = uint32(C.wasm_limits_max_default)
+func LimitMaxUnbound() uint32 {
+	return uint32(C.limit_max_unbound())
+}
 
 type Limits struct {
 	_inner C.wasm_limits_t

--- a/wasmer/limits_test.go
+++ b/wasmer/limits_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLimitMaxDefault(t *testing.T) {
-	assert.Equal(t, LimitMaxUnbound, uint32(0xffffffff))
+	assert.Equal(t, LimitMaxUnbound(), uint32(0xffffffff))
 }
 
 func TestLimits(t *testing.T) {


### PR DESCRIPTION
This avoid errors when trying to build with GCC < 8

Closes #149

Here are the result with all the `gcc`/`clang` versions I tested:

```
Running with gcc-7 (Homebrew GCC 7.5.0_2) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
ok  	command-line-arguments	0.008s

Running with gcc-8 (Homebrew GCC 8.4.0_1) 8.4.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
ok  	command-line-arguments	0.008s

Running with gcc-9 (Homebrew GCC 9.3.0) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
ok  	command-line-arguments	0.009s

Running with gcc-10 (Homebrew GCC 10.2.0) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
ok  	command-line-arguments	0.008s

Running with clang version 11.0.0
Target: x86_64-apple-darwin20.2.0
Thread model: posix
InstalledDir: /usr/local/opt/llvm/bin
ok  	command-line-arguments	0.009s
```