### PR TITLE
fix(error) Lock `newErrorFromWasmer` to OS thread

### DIFF
--- a/wasmer/target.go
+++ b/wasmer/target.go
@@ -48,10 +48,16 @@ func NewTriple(triple string) (*Triple, error) {
 	cTripleName := newName(triple)
 	defer C.wasm_name_delete(&cTripleName)
 
-	cTriple := C.wasm_triple_new(&cTripleName)
+	var cTriple *C.wasm_triple_t
 
-	if cTriple == nil {
-		return nil, newErrorFromWasmer()
+	err := maybeNewErrorFromWasmer(func() bool {
+		cTriple := C.wasm_triple_new(&cTripleName)
+
+		return cTriple == nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
 	return newTriple(cTriple), nil
@@ -89,8 +95,12 @@ func (self *CpuFeatures) Add(feature string) error {
 	cFeature := newName(feature)
 	defer C.wasm_name_delete(&cFeature)
 
-	if !C.wasm_cpu_features_add(self.inner(), &cFeature) {
-		return newErrorFromWasmer()
+	err := maybeNewErrorFromWasmer(func() bool {
+		return false == C.wasm_cpu_features_add(self.inner(), &cFeature)
+	})
+
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/wasmer/wat.go
+++ b/wasmer/wat.go
@@ -19,21 +19,25 @@ import (
 func Wat2Wasm(wat string) ([]byte, error) {
 	var watBytes C.wasm_byte_vec_t
 	var watLength = len(wat)
+
 	C.wasm_byte_vec_new(&watBytes, C.size_t(watLength), C.CString(wat))
+	defer C.wasm_byte_vec_delete(&watBytes)
 
 	var wasm C.wasm_byte_vec_t
-	C.wat2wasm(
-		&watBytes,
-		&wasm,
-	)
-	C.wasm_byte_vec_delete(&watBytes)
 
-	if wasm.data == nil {
-		return nil, newErrorFromWasmer()
+	err := maybeNewErrorFromWasmer(func() bool {
+		C.wat2wasm(&watBytes, &wasm)
+
+		return wasm.data == nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
+	defer C.wasm_byte_vec_delete(&wasm)
+
 	wasmBytes := C.GoBytes(unsafe.Pointer(wasm.data), C.int(wasm.size))
-	C.wasm_byte_vec_delete(&wasm)
 
 	return wasmBytes, nil
 }


### PR DESCRIPTION
Revamping of https://github.com/wasmerio/wasmer-go/pull/117. See
https://github.com/wasmerio/wasmer-go/issues/96 to get more details.

This patch renames `newErrorFromWasmer` to `_newErrorFromWasmer`. It creates a new function named `maybeNewErrorFromWasmer` which creates a new `*Error` from the Wasmer API, if and only if the given block returns `true` (which means that it has failed).

Then the code has been adapted consequently.