### PR TITLE
adding a build tag specific cgo bridge

### DIFF
--- a/wasmer/cgo.go
+++ b/wasmer/cgo.go
@@ -1,3 +1,5 @@
+// +build !customlib
+
 package wasmer
 
 // #cgo CFLAGS: -I${SRCDIR}/packaged/include

--- a/wasmer/cgo_customlib.go
+++ b/wasmer/cgo_customlib.go
@@ -1,0 +1,12 @@
+// +build customlib
+
+package wasmer
+
+// User is expected to provide the CGO_LDFLAGS and CGO_CFLAGS that point to appropriate wasmer build directories
+// for example:
+// CGO_CFLAGS="-I/wasmer/lib/c-api/"
+// CGO_LDFLAGS="-Wl,-rpath,/wasmer/target/x86_64-unknown-linux-musl/release/ -L/wasmer/target/x86_64-unknown-linux-musl/release/ -pthread -lwasmer_c_api -lm -ldl -static"
+//
+//
+// #include <wasmer_wasm.h>
+import "C"


### PR DESCRIPTION
# Purpose of this PR
I am attempting to do some static linking and also to use an alternative LIBC implementation (musl) this requires that I have greater control over the LDFLAGS and CFLAGS.  The current flags hard code the location of the library and include files, requiring some file copypasta.

# What this PR does
Adds an optional `customlib` build tag that when specified during builds requires that the user provide all the CFLAG and LDFLAG variables.

# What this allows
I can build the upstream wasmerio/wasmer package with custom targets, etc.. and then build my golang application with total control over which wasmer library file is included.

# Example Usage
Assuming that i have cloned the wasmer repo to `/wasmer` and built an appropriate wasmer C-API I can then perform the following to get a sweet sweet statically compiled executable using the MUSL libc:

```
export CGO_CFLAGS="-I/wasmer/lib/c-api/"
export CGO_LDFLAGS="-Wl,-rpath,/wasmer/target/x86_64-unknown-linux-musl/release/ -L/wasmer/target/x86_64-unknown-linux-musl/release/ -pthread -lwasmer_c_api -lm -ldl -static"
CC=/usr/bin/musl-gcc go build -tags customlib
```

The additional build tag will not affect existing users at all.