### PR TITLE
fix(go) Force `go mod vendor` to copy the `packaged/` directory.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,6 @@ jobs:
           default: true
           override: true
 
-      - uses: Swatinem/rust-cache@v1
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/wasmer/cgo.go
+++ b/wasmer/cgo.go
@@ -11,3 +11,9 @@ package wasmer
 //
 // #include <wasmer_wasm.h>
 import "C"
+
+// See https://github.com/golang/go/issues/26366.
+import (
+	_ "github.com/wasmerio/wasmer-go/wasmer/packaged/include"
+	_ "github.com/wasmerio/wasmer-go/wasmer/packaged/lib"
+)

--- a/wasmer/packaged/include/dummy.go
+++ b/wasmer/packaged/include/dummy.go
@@ -1,0 +1,2 @@
+// See https://github.com/golang/go/issues/26366.
+package include

--- a/wasmer/packaged/lib/darwin-amd64/dummy.go
+++ b/wasmer/packaged/lib/darwin-amd64/dummy.go
@@ -1,0 +1,2 @@
+// See https://github.com/golang/go/issues/26366.
+package darwin_amd64

--- a/wasmer/packaged/lib/dummy.go
+++ b/wasmer/packaged/lib/dummy.go
@@ -1,0 +1,8 @@
+// See https://github.com/golang/go/issues/26366.
+package lib
+
+import (
+	_ "github.com/wasmerio/wasmer-go/wasmer/packaged/lib/darwin-amd64"
+	_ "github.com/wasmerio/wasmer-go/wasmer/packaged/lib/linux-aarch64"
+	_ "github.com/wasmerio/wasmer-go/wasmer/packaged/lib/linux-amd64"
+)

--- a/wasmer/packaged/lib/linux-aarch64/dummy.go
+++ b/wasmer/packaged/lib/linux-aarch64/dummy.go
@@ -1,0 +1,2 @@
+// See https://github.com/golang/go/issues/26366.
+package linux_aarch64

--- a/wasmer/packaged/lib/linux-amd64/dummy.go
+++ b/wasmer/packaged/lib/linux-amd64/dummy.go
@@ -1,0 +1,2 @@
+// See https://github.com/golang/go/issues/26366.
+package linux_amd64


### PR DESCRIPTION
Fix #196.

As explained in https://github.com/golang/go/issues/26366, `go mod
vendor` is acting unexpectely. If a directory doesn't contain a `.go`
file, then it's not copied.

This patch fixes that. Or try to.

It's not tested on the CI because it's not that easy. We would need to create a new Go project, requiring `wasmer-go`, `go mod vendor`, then having small test inside this project that uses `wasmer-go`. If everything works correctly, then it's good.

For the moment, the patch will be tested by @cohix!