### PR TITLE
feat(config) Add `Config.UseSinglepassCompiler`

### DIFF
--- a/wasmer/config.go
+++ b/wasmer/config.go
@@ -59,6 +59,16 @@ func (self *Config) UseLLVMCompiler() {
 	C.wasm_config_set_engine(self.inner(), C.LLVM)
 }
 
+// UseSinglepassCompiler sets the compiler to Singlepass in the
+// configuration.
+//
+//   config := NewConfig()
+//   config.UseSinglepassCompiler()
+//
+func (self *Config) UseSinglepassCompiler() {
+	C.wasm_config_set_engine(self.inner(), C.SINGLEPASS)
+}
+
 // Use a specific target for doing cross-compilation.
 //
 //   triple, _ := NewTriple("aarch64-unknown-linux-gnu")


### PR DESCRIPTION
The current `libwasmer` only embeds the Cranelift compiler, but with https://github.com/wasmerio/wasmer/pull/2123 we will have LLVM and Singlepass if available for the host.

Anyway, we aren't blocked, we can validated and merged this PR, so that everything is ready.