### PR TITLE
test(config) Use parameterized tests to check all configurations

### DIFF
--- a/wasmer/config.go
+++ b/wasmer/config.go
@@ -28,8 +28,10 @@ func (self *Config) inner() *C.wasm_config_t {
 //   config := NewConfig()
 //   config.UseJITEngine()
 //
-func (self *Config) UseJITEngine() {
+func (self *Config) UseJITEngine() *Config {
 	C.wasm_config_set_engine(self.inner(), C.JIT)
+
+	return self
 }
 
 // UseNativeEngine sets the engine to Native in the configuration.
@@ -37,8 +39,10 @@ func (self *Config) UseJITEngine() {
 //   config := NewConfig()
 //   config.UseNativeEngine()
 //
-func (self *Config) UseNativeEngine() {
+func (self *Config) UseNativeEngine() *Config {
 	C.wasm_config_set_engine(self.inner(), C.NATIVE)
+
+	return self
 }
 
 // UseCraneliftCompiler sets the compiler to Cranelift in the configuration.
@@ -46,8 +50,10 @@ func (self *Config) UseNativeEngine() {
 //   config := NewConfig()
 //   config.UseCraneliftCompiler()
 //
-func (self *Config) UseCraneliftCompiler() {
+func (self *Config) UseCraneliftCompiler() *Config {
 	C.wasm_config_set_engine(self.inner(), C.CRANELIFT)
+
+	return self
 }
 
 // UseLLVMCompiler sets the compiler to LLVM in the configuration.
@@ -55,8 +61,10 @@ func (self *Config) UseCraneliftCompiler() {
 //   config := NewConfig()
 //   config.UseLLVMCompiler()
 //
-func (self *Config) UseLLVMCompiler() {
+func (self *Config) UseLLVMCompiler() *Config {
 	C.wasm_config_set_engine(self.inner(), C.LLVM)
+
+	return self
 }
 
 // UseSinglepassCompiler sets the compiler to Singlepass in the
@@ -65,8 +73,10 @@ func (self *Config) UseLLVMCompiler() {
 //   config := NewConfig()
 //   config.UseSinglepassCompiler()
 //
-func (self *Config) UseSinglepassCompiler() {
+func (self *Config) UseSinglepassCompiler() *Config {
 	C.wasm_config_set_engine(self.inner(), C.SINGLEPASS)
+
+	return self
 }
 
 // Use a specific target for doing cross-compilation.
@@ -77,6 +87,8 @@ func (self *Config) UseSinglepassCompiler() {
 //
 //   config := NewConfig()
 //   config.UseTarget(target)
-func (self *Config) UseTarget(target *Target) {
+func (self *Config) UseTarget(target *Target) *Config {
 	C.wasm_config_set_target(self.inner(), target.inner())
+
+	return self
 }

--- a/wasmer/config_test.go
+++ b/wasmer/config_test.go
@@ -48,22 +48,24 @@ func TestConfig_AllCombinations(t *testing.T) {
 		configs = append(configs, Test{"Cranelift", "Native", NewConfig().UseCraneliftCompiler().UseNativeEngine()})
 	}
 
-	// LLVM with the JIT engine works on Linux+Darwin/amd64.
-	if is_amd64 && (is_linux || is_darwin) {
-		configs = append(configs, Test{"LLVM", "JIT", NewConfig().UseLLVMCompiler().UseJITEngine()})
-	}
+	/*
+		LLVM isn't part of the prepacked `libwasmer` for the moment.
 
-	// LLVM with the Native engine works on Linux+Darwin/amd64.
-	if is_amd64 && (is_linux || is_darwin) {
-		configs = append(configs, Test{"LLVM", "Native", NewConfig().UseLLVMCompiler().UseNativeEngine()})
-	}
+			// LLVM with the JIT engine works on Linux+Darwin/amd64.
+			if is_amd64 && (is_linux || is_darwin) {
+				configs = append(configs, Test{"LLVM", "JIT", NewConfig().UseLLVMCompiler().UseJITEngine()})
+			}
+
+			// LLVM with the Native engine works on Linux+Darwin/amd64.
+			if is_amd64 && (is_linux || is_darwin) {
+				configs = append(configs, Test{"LLVM", "Native", NewConfig().UseLLVMCompiler().UseNativeEngine()})
+			}
+	*/
 
 	// Singlepass with the JIT engine works on Linux+Darwin/amd64.
-	/*
-		if is_amd64 && (is_linux || is_darwin) {
-			configs = append(configs, Test{"Singlepass", "JIT", NewConfig().UseSinglepassCompiler().UseJITEngine()})
-		}
-	*/
+	if is_amd64 && (is_linux || is_darwin) {
+		configs = append(configs, Test{"Singlepass", "JIT", NewConfig().UseSinglepassCompiler().UseJITEngine()})
+	}
 
 	for _, test := range configs {
 		t.Run(

--- a/wasmer/config_test.go
+++ b/wasmer/config_test.go
@@ -1,6 +1,7 @@
 package wasmer
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"runtime"
 	"testing"
@@ -25,182 +26,64 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, result, int32(42))
 }
 
-func TestConfig_UseJITEngine(t *testing.T) {
-	config := NewConfig()
-	config.UseJITEngine()
+func TestConfig_AllCombinations(t *testing.T) {
+	type Test struct {
+		compilerName string
+		engineName   string
+		config       *Config
+	}
+	var configs = []Test{}
 
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
+	is_amd64 := runtime.GOARCH == "amd64"
+	//is_aarch64 := runtime.GOARCH == "arm64"
+	is_linux := runtime.GOOS == "linux"
+	is_darwin := runtime.GOOS == "darwin"
+	//is_windows := runtime.GOOS == "windows"
 
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
+	// Cranelift with the JIT engine works everywhere
+	configs = append(configs, Test{"Cranelift", "JIT", NewConfig().UseCraneliftCompiler().UseJITEngine()})
 
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_UseNativeEngine(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		return
+	// Cranelift with the Native engine works on Linux+Darwin/amd64.
+	if is_amd64 && (is_linux || is_darwin) {
+		configs = append(configs, Test{"Cranelift", "Native", NewConfig().UseCraneliftCompiler().UseNativeEngine()})
 	}
 
-	config := NewConfig()
-	config.UseNativeEngine()
-
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
-
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
-
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_UseCraneliftCompiler(t *testing.T) {
-	config := NewConfig()
-	config.UseCraneliftCompiler()
-
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
-
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
-
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_UseLLVMCompiler(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		return
+	// LLVM with the JIT engine works on Linux+Darwin/amd64.
+	if is_amd64 && (is_linux || is_darwin) {
+		configs = append(configs, Test{"LLVM", "JIT", NewConfig().UseLLVMCompiler().UseJITEngine()})
 	}
 
-	config := NewConfig()
-	config.UseLLVMCompiler()
-
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
-
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
-
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_JITWithCranelift(t *testing.T) {
-	config := NewConfig()
-	config.UseJITEngine()
-	config.UseCraneliftCompiler()
-
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
-
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
-
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_JITWithLLVM(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		return
+	// LLVM with the Native engine works on Linux+Darwin/amd64.
+	if is_amd64 && (is_linux || is_darwin) {
+		configs = append(configs, Test{"LLVM", "Native", NewConfig().UseLLVMCompiler().UseNativeEngine()})
 	}
 
-	config := NewConfig()
-	config.UseJITEngine()
-	config.UseLLVMCompiler()
+	// Singlepass with the JIT engine works on Linux+Darwin/amd64.
+	/*
+		if is_amd64 && (is_linux || is_darwin) {
+			configs = append(configs, Test{"Singlepass", "JIT", NewConfig().UseSinglepassCompiler().UseJITEngine()})
+		}
+	*/
 
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
+	for _, test := range configs {
+		t.Run(
+			fmt.Sprintf("compiler=%s, engine=%s", test.compilerName, test.engineName),
+			func(t *testing.T) {
+				engine := NewEngineWithConfig(test.config)
+				store := NewStore(engine)
+				module, err := NewModule(store, testGetBytes("tests.wasm"))
+				assert.NoError(t, err)
 
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
+				instance, err := NewInstance(module, NewImportObject())
+				assert.NoError(t, err)
 
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
+				sum, err := instance.Exports.GetFunction("sum")
+				assert.NoError(t, err)
 
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_NativeWithCranelift(t *testing.T) {
-	config := NewConfig()
-	config.UseNativeEngine()
-	config.UseCraneliftCompiler()
-
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
-
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
-
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
-}
-
-func TestConfig_NativeWithLLVM(t *testing.T) {
-	if runtime.GOARCH != "amd64" {
-		return
+				result, err := sum(37, 5)
+				assert.NoError(t, err)
+				assert.Equal(t, result, int32(42))
+			},
+		)
 	}
-
-	config := NewConfig()
-	config.UseNativeEngine()
-	config.UseLLVMCompiler()
-
-	engine := NewEngineWithConfig(config)
-	store := NewStore(engine)
-	module, err := NewModule(store, testGetBytes("tests.wasm"))
-	assert.NoError(t, err)
-
-	instance, err := NewInstance(module, NewImportObject())
-	assert.NoError(t, err)
-
-	sum, err := instance.Exports.GetFunction("sum")
-	assert.NoError(t, err)
-
-	result, err := sum(37, 5)
-	assert.NoError(t, err)
-	assert.Equal(t, result, int32(42))
 }


### PR DESCRIPTION
This patch updates `config_test.go` to better test all combinations between compilers and engines and platforms and architectures

The Singlepass compiler is missing for the moment, since we are waiting on #204 to get merged before.