### PR TITLE
fix(function) Avoid calling `Function.Type` for every call

### DIFF
--- a/wasmer/function.go
+++ b/wasmer/function.go
@@ -277,9 +277,10 @@ func (self *Function) Native() NativeFunction {
 		return self.lazyNative
 	}
 
+	ty := self.Type()
+	expectedParameters := ty.Params()
+
 	self.lazyNative = func(receivedParameters ...interface{}) (interface{}, error) {
-		ty := self.Type()
-		expectedParameters := ty.Params()
 		numberOfReceivedParameters := len(receivedParameters)
 		numberOfExpectedParameters := len(expectedParameters)
 		diff := numberOfExpectedParameters - numberOfReceivedParameters


### PR DESCRIPTION
Address #201.

When `Function.Call` is called, a new `FunctionType` is created with
`Function.Type`. The `FunctionType` is “owned by” `Function`, and
isn't freed until `Function` is freed.

When calling the same function again and again in a loop, all the
`FunctionType` will stack and increase the memory size.

By moving `FunctionType` outside the `lazyNative` function, a unique
`FunctionType` is created, thus saving a ton of calls and memory.