### PR TITLE
test(ci) Test `wasmer-nightly` every night at 2am

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - master
       - staging
       - trying
+  schedule:
+    - cron: '0 2 * * *' # To test `wasmer-nightly` with `libwasmer_archive_name`.
 
 jobs:
   test:


### PR DESCRIPTION
Close #208.

We already fetch the archive for `libwasmer` from `wasmer-nighty`. By scheduling this workflow, we ensure to test against the nightly versions of Wasmer too.