### PR TITLE
correctly handle I64 (and other) values returned from imported functions

### DIFF
--- a/wasmer/value.go
+++ b/wasmer/value.go
@@ -294,8 +294,7 @@ func toValueVec(list []Value, vec *C.wasm_val_vec_t) {
 	values := make([]C.wasm_val_t, numberOfValues)
 
 	for nth, item := range list {
-		value, err := fromGoValue(item.I32(), item.Kind())
-
+		value, err := fromGoValue(item.Unwrap(), item.Kind())
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
I was attempting to upgrade to the new wasmer version when I found that any imported functions that returned I64 caused "panic: Cannot convert value to `int32`". it seems it was due to always trying to convert the return value to I32. This PR resolves that issue.