### PR TITLE
fix: set store field in Module when calling DeserializeModule()

### DIFF
--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -237,6 +237,7 @@ func DeserializeModule(store *Store, bytes []byte) (*Module, error) {
 	err := maybeNewErrorFromWasmer(func() bool {
 		self = &Module{
 			_inner: C.to_wasm_module_deserialize(store.inner(), bytesPtr, C.size_t(bytesLength)),
+			store:  store,
 		}
 
 		return self._inner == nil
@@ -245,6 +246,10 @@ func DeserializeModule(store *Store, bytes []byte) (*Module, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	runtime.SetFinalizer(self, func(self *Module) {
+		C.wasm_module_delete(self.inner())
+	})
 
 	return self, nil
 }

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -247,6 +247,7 @@ func DeserializeModule(store *Store, bytes []byte) (*Module, error) {
 		return nil, err
 	}
 
+	runtime.KeepAlive(bytes)
 	runtime.SetFinalizer(self, func(self *Module) {
 		C.wasm_module_delete(self.inner())
 	})

--- a/wasmer/module_test.go
+++ b/wasmer/module_test.go
@@ -200,4 +200,7 @@ func TestModuleDeserialize(t *testing.T) {
 	functionType := type0.IntoFunctionType()
 	assert.Equal(t, len(functionType.Params()), 2)
 	assert.Equal(t, len(functionType.Results()), 0)
+
+	_, err = NewInstance(moduleAgain, NewImportObject())
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
When calling `DeserializeModule()`, the `store` field on `Module{}` isn't set which causes `NewInstance()` with that module to panic. This PR fixes that.