### PR TITLE
fix: Force finalizers to explore the graph of objects

### DIFF
--- a/wasmer/function.go
+++ b/wasmer/function.go
@@ -46,12 +46,12 @@ func newFunction(pointer *C.wasm_func_t, environment *functionEnvironment, owned
 	}
 
 	if ownedBy == nil {
-		runtime.SetFinalizer(function, func(function *Function) {
-			if function.environment != nil {
-				hostFunctionStore.remove(function.environment.hostFunctionStoreIndex)
+		runtime.SetFinalizer(function, func(self *Function) {
+			if self.environment != nil {
+				hostFunctionStore.remove(self.environment.hostFunctionStoreIndex)
 			}
 
-			C.wasm_func_delete(function.inner())
+			C.wasm_func_delete(self.inner())
 		})
 	}
 

--- a/wasmer/importtype.go
+++ b/wasmer/importtype.go
@@ -16,9 +16,8 @@ func newImportTypes(module *Module) *importTypes {
 	self := &importTypes{}
 	C.wasm_module_imports(module.inner(), &self._inner)
 
-	runtime.KeepAlive(module)
 	runtime.SetFinalizer(self, func(self *importTypes) {
-		C.wasm_importtype_vec_delete(self.inner())
+		self.close()
 	})
 
 	numberOfImportTypes := int(self.inner().size)
@@ -43,6 +42,11 @@ func (self *importTypes) inner() *C.wasm_importtype_vec_t {
 	return &self._inner
 }
 
+func (self *importTypes) close() {
+	runtime.SetFinalizer(self, nil)
+	C.wasm_importtype_vec_delete(&self._inner)
+}
+
 // ImportType is a descriptor for an imported value into a WebAssembly
 // module.
 type ImportType struct {
@@ -54,8 +58,8 @@ func newImportType(pointer *C.wasm_importtype_t, ownedBy interface{}) *ImportTyp
 	importType := &ImportType{_inner: pointer, _ownedBy: ownedBy}
 
 	if ownedBy == nil {
-		runtime.SetFinalizer(importType, func(importType *ImportType) {
-			C.wasm_importtype_delete(importType.inner())
+		runtime.SetFinalizer(importType, func(self *ImportType) {
+			self.Close()
 		})
 	}
 
@@ -142,4 +146,14 @@ func (self *ImportType) Type() *ExternType {
 	runtime.KeepAlive(self)
 
 	return newExternType(ty, self.ownedBy())
+}
+
+// Force to close the ImportType.
+//
+// A runtime finalizer is registered on the ImportType, but it is
+// possible to force the destruction of the ImportType by calling
+// Close manually.
+func (self *ImportType) Close() {
+	runtime.SetFinalizer(self, nil)
+	C.wasm_importtype_delete(self.inner())
 }

--- a/wasmer/store.go
+++ b/wasmer/store.go
@@ -31,7 +31,7 @@ func NewStore(engine *Engine) *Store {
 	}
 
 	runtime.SetFinalizer(self, func(self *Store) {
-		C.wasm_store_delete(self.inner())
+		self.Close()
 	})
 
 	return self
@@ -39,4 +39,13 @@ func NewStore(engine *Engine) *Store {
 
 func (self *Store) inner() *C.wasm_store_t {
 	return self._inner
+}
+
+// Force to close the Store.
+//
+// A runtime finalizer is registered on the Store, but it is possible
+// to force the destruction of the Store by calling Close manually.
+func (self *Store) Close() {
+	runtime.SetFinalizer(self, nil)
+	C.wasm_store_delete(self.inner())
 }


### PR DESCRIPTION
First, this patch provides new `Close` methods on some “top types”
(`Store`, `Module`, `Instance` etc.). The `Close` methods are
redundant to the runtime finalizers, but they are useful to force to
destruct a specific type manually before the Go GC collect it.

Note that calling `Close` will remove the runtime finalizer attached
to the object.

Note that runtime finalizers call the `Close` method if defined on the
current object.

Second, this patch forces the destructors (now the `Close` methods) to
destruct the children attached to the current object. Let's see it in
details:

* `Module` now has two new fields `importTypes *importTypes` and
  `exportTypes *exportTypes`. The value is null, except if the
  `Imports` or `Exports` methods are called. They will store their
  respective results in their respective fields. The goal of this
  change is twofold:

  1. Avoiding computing the same import and export types multiple
     times each time one of the method is called,

  2. By holding a reference to the private `importTypes` and
     `exportTypes`, `Module` can free them. Before that, the objects
     were orphan and the garbage collector had difficulties to collect
     them.

* `Instance` now forces to free its `Exports`,

* `Exports` now force to free all the items of its `exports` map
  field. Before this patch, only the `_inner` C pointer was freed, but
  not the map. I have no idea why the map wasn't collected by the Go
  GC.

Running the script written by @prep in
https://github.com/wasmerio/wasmer-go/issues/262 shows that there is
no more memory leaks.


Fix #262.
Fix #269.