### PR TITLE
Enable client to pass through their own function as an unsafe.Pointer

### DIFF
--- a/wasmer/config.go
+++ b/wasmer/config.go
@@ -199,15 +199,19 @@ func (self *Config) PushMeteringMiddleware(maxGasUsageAllowed uint64, opMap map[
 }
 
 // PushMeteringMiddlewarePtr allows the middleware metering to be engaged on an unsafe.Pointer
-// this pointer must be a to C based function with a signature of  extern uint64_t cost-delegate_func(enum wasmer_parser_operator_t op);
+// this pointer must be a to C based function with a signature of:
+//        extern uint64_t cost-delegate_func(enum wasmer_parser_operator_t op);
+// package main
 //
 // #include <wasmer.h>
 // extern uint64_t metering_delegate_alt(enum wasmer_parser_operator_t op);
 // import "C"
 // import "unsafe"
+//
 // func getInternalCPointer() unsafe.Pointer {
 //	  return unsafe.Pointer(C.metering_delegate_alt)
 // }
+//
 // //export metering_delegate_alt
 // func metering_delegate_alt(op C.wasmer_parser_operator_t) C.uint64_t {
 //	v, b := opCodeMap[Opcode(op)]
@@ -216,9 +220,10 @@ func (self *Config) PushMeteringMiddleware(maxGasUsageAllowed uint64, opMap map[
 //   }
 //   return C.uint64_t(v)
 // }
+//
 // void main(){
-//   config := NewConfig()
-//   config.PushMeteringMiddlewarePtr(800000000, getInternalCPointer())
+//    config := NewConfig()
+//    config.PushMeteringMiddlewarePtr(800000000, getInternalCPointer())
 // }
 func (self *Config) PushMeteringMiddlewarePtr(maxGasUsageAllowed uint64, p unsafe.Pointer) *Config {
 	C.wasm_config_push_middleware(self.inner(), C.wasmer_metering_as_middleware(C.wasmer_metering_new(getPlatformLong(maxGasUsageAllowed), (*[0]byte)(p))))

--- a/wasmer/config.go
+++ b/wasmer/config.go
@@ -194,7 +194,7 @@ func (self *Config) PushMeteringMiddleware(maxGasUsageAllowed uint64, opMap map[
 		// REVIEW only allowing this to be set once
 		opCodeMap = opMap
 	}
-	C.wasm_config_push_middleware(self.inner(), C.wasmer_metering_as_middleware(C.wasmer_metering_new(C.ulong(maxGasUsageAllowed), (*[0]byte)(C.metering_delegate))))
+	C.wasm_config_push_middleware(self.inner(), C.wasmer_metering_as_middleware(C.wasmer_metering_new(getPlatformLong(maxGasUsageAllowed), (*[0]byte)(C.metering_delegate))))
 	return self
 }
 
@@ -221,7 +221,7 @@ func (self *Config) PushMeteringMiddleware(maxGasUsageAllowed uint64, opMap map[
 //   config.PushMeteringMiddlewarePtr(800000000, getInternalCPointer())
 // }
 func (self *Config) PushMeteringMiddlewarePtr(maxGasUsageAllowed uint64, p unsafe.Pointer) *Config {
-	C.wasm_config_push_middleware(self.inner(), C.wasmer_metering_as_middleware(C.wasmer_metering_new(C.ulong(maxGasUsageAllowed), (*[0]byte)(p))))
+	C.wasm_config_push_middleware(self.inner(), C.wasmer_metering_as_middleware(C.wasmer_metering_new(getPlatformLong(maxGasUsageAllowed), (*[0]byte)(p))))
 	return self
 }
 

--- a/wasmer/config.go
+++ b/wasmer/config.go
@@ -200,7 +200,7 @@ func (self *Config) PushMeteringMiddleware(maxGasUsageAllowed uint64, opMap map[
 
 // PushMeteringMiddlewarePtr allows the middleware metering to be engaged on an unsafe.Pointer
 // this pointer must be a to C based function with a signature of:
-//        extern uint64_t cost-delegate_func(enum wasmer_parser_operator_t op);
+//        extern uint64_t cost_delegate_func(enum wasmer_parser_operator_t op);
 // package main
 //
 // #include <wasmer.h>

--- a/wasmer/config_darwin.go
+++ b/wasmer/config_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin
+// +build darwin
+
+package wasmer
+
+// #include <wasmer.h>
+// extern uint64_t metering_delegate(enum wasmer_parser_operator_t op);
+import "C"
+
+func getPlatformLong(v uint64) C.ulonglong {
+	return C.ulonglong(v)
+}

--- a/wasmer/config_linux.go
+++ b/wasmer/config_linux.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+// +build !darwin
+
+package wasmer
+
+// #include <wasmer.h>
+// extern uint64_t metering_delegate(enum wasmer_parser_operator_t op);
+import "C"
+
+func getPlatformLong(v uint64) C.ulong {
+	return C.ulong(v)
+}

--- a/wasmer/config_test.go
+++ b/wasmer/config_test.go
@@ -68,6 +68,28 @@ func TestConfigForMetering(t *testing.T) {
 	// total instruction count should be 27
 }
 
+func TestConfigForMeteringFn(t *testing.T) {
+
+	config := NewConfig().PushMeteringMiddlewarePtr(800000000, getInternalCPointer())
+	engine := NewEngineWithConfig(config)
+	store := NewStore(engine)
+	module, err := NewModule(store, testGetBytes("tests.wasm"))
+	assert.NoError(t, err)
+
+	instance, err := NewInstance(module, NewImportObject())
+	assert.NoError(t, err)
+
+	sum, err := instance.Exports.GetFunction("sum")
+	assert.NoError(t, err)
+
+	result, err := sum(37, 5)
+	assert.NoError(t, err)
+	assert.Equal(t, result, int32(42))
+	rp := instance.GetRemainingPoints()
+	assert.Equal(t, int(rp), 800000000-7)
+	// total instruction count should be 27
+}
+
 func TestConfig_AllCombinations(t *testing.T) {
 	type Test struct {
 		compilerName string

--- a/wasmer/config_test_helper.go
+++ b/wasmer/config_test_helper.go
@@ -1,0 +1,21 @@
+package wasmer
+
+// #include <wasmer.h>
+// extern uint64_t metering_delegate_alt(enum wasmer_parser_operator_t op);
+import "C"
+import "unsafe"
+
+func getInternalCPointer() unsafe.Pointer {
+	return unsafe.Pointer(C.metering_delegate_alt)
+}
+
+//export metering_delegate_alt
+func metering_delegate_alt(op C.wasmer_parser_operator_t) C.uint64_t {
+	// a simple alogorithm for now just map from opcode to cost directly
+	// all the responsibility is placed on the caller of PushMeteringMiddleware
+	v, b := opCodeMap[Opcode(op)]
+	if !b {
+		return 0 // no value means no cost
+	}
+	return C.uint64_t(v)
+}


### PR DESCRIPTION
I saw the last was pulled before I could land this.  I think this gives the best of both worlds.