### PR TITLE
Fixes go GC crash on trap

### DIFF
--- a/examples/example_early_exit_test.go
+++ b/examples/example_early_exit_test.go
@@ -17,6 +17,8 @@ package wasmer
 
 import (
 	"fmt"
+	"runtime"
+
 	"github.com/wasmerio/wasmer-go/wasmer"
 )
 
@@ -100,6 +102,10 @@ func ExampleFunction_Call() {
 	}
 
 	fmt.Println("Exited early with:", err)
+
+	// These lines are here to ensure that SetFinalizer works correctly
+	runtime.GC()
+	runtime.GC()
 
 	// Output:
 	// Compiling module...

--- a/wasmer/error.go
+++ b/wasmer/error.go
@@ -65,7 +65,7 @@ type TrapError struct {
 }
 
 func newErrorFromTrap(pointer *C.wasm_trap_t) *TrapError {
-	trap := newTrap(pointer, nil)
+	trap := newTrapFromPointer(pointer, nil)
 
 	return &TrapError{
 		message: trap.Message(),

--- a/wasmer/function.go
+++ b/wasmer/function.go
@@ -117,11 +117,8 @@ func function_trampoline(env unsafe.Pointer, args *C.wasm_val_vec_t, res *C.wasm
 	results, err := (function)(arguments)
 
 	if err != nil {
-		trap := NewTrap(hostFunction.store, err.Error())
-
-		runtime.KeepAlive(trap)
-
-		return trap.inner()
+		pointer := newWasmTrap(hostFunction.store, err.Error())
+		return pointer
 	}
 
 	toValueVec(results, res)
@@ -191,11 +188,8 @@ func function_with_environment_trampoline(env unsafe.Pointer, args *C.wasm_val_v
 	results, err := (function)(hostFunction.userEnvironment, arguments)
 
 	if err != nil {
-		trap := NewTrap(hostFunction.store, err.Error())
-
-		runtime.KeepAlive(trap)
-
-		return trap.inner()
+		pointer := newWasmTrap(hostFunction.store, err.Error())
+		return pointer
 	}
 
 	toValueVec(results, res)


### PR DESCRIPTION
Fixes https://github.com/wasmerio/wasmer-go/issues/291. Please, check https://github.com/wasmerio/wasmer-go/issues/291#issuecomment-1104443467 for the detailed description of the problem.

The crash can be reproduced in the `master` branch by adding `runtime.GC()` twice to the end of `examples/example_early_exit_test.go` file.