### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	wasmer "github.com/wasmerio/wasmer-go/wasmer"
 )
 
 func main() {
-    wasmBytes, _ := ioutil.ReadFile("simple.wasm")
+    wasmBytes, _ := os.ReadFile("simple.wasm")
 
     engine := wasmer.NewEngine()
     store := wasmer.NewStore(engine)


### PR DESCRIPTION
`io/ioutil` is deprecated sinze Go 1.16